### PR TITLE
Download to temp then move to local file

### DIFF
--- a/src/File/AddCommand.cs
+++ b/src/File/AddCommand.cs
@@ -139,10 +139,18 @@ namespace Microsoft.DotNet
                     if (Path.GetDirectoryName(path)?.Length > 0)
                         Directory.CreateDirectory(Path.GetDirectoryName(path));
 
-                    using (var stream = File.Open(path, FileMode.Create))
+                    var tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                    try
                     {
+                        using var stream = File.Open(tempPath, FileMode.Create);
                         await response.Content.CopyToAsync(stream);
                     }
+                    catch (Exception) // Delete temp file on error
+                    {
+                        File.Delete(tempPath);
+                        throw;
+                    }
+                    File.Move(tempPath, path, overwrite: true);
 
                     Configuration.SetString("file", file.Path, "url", originalUri.ToString());
 


### PR DESCRIPTION
If a download fails part of the way then an incomplete file may be left locally. This PR avoid this by downloading the file to a temporary location & name before moving it to its local location (replacing the file if it exists). The download operation thus becomes atomic.