### PR TITLE
🌱 Create init command to seed directory from remote config 

### DIFF
--- a/File.sln
+++ b/File.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		src\Directory.props = src\Directory.props
 		src\Directory.targets = src\Directory.targets
+		readme.md = readme.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "File", "src\File\File.csproj", "{F98A74FE-B9B7-49EF-9E00-1911B4E244CB}"

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ Usage:
         add        downloads a file or GitHub repository or directory from a URL
         changes    checks remote URLs for changes and lists the status of local files
         delete     deletes a file and its corresponding config entry from the local directory
+        init       initializes the local directory from one or more remote .netconfig files
         list       lists the config entries and the status of their corresponding files
         sync       synchronizes with remote URLs, deleting local files and directories as needed
         update     updates local files from remote URLs, does not prune deleted remote files
@@ -44,8 +45,9 @@ disambiguate file (local path) from url (remote file location).
 
 Examples:
 
+    dotnet file init [url]          // seeds the current directory with all files/URLs listed in a remote URL
     dotnet file add [url]           // downloads a file to the current directory and adds its URL+ETag in dotnet-config
-    dotnet file add [url] [file]    // downloads the url to the (relative) relative file local path specifed and adds
+    dotnet file add [url] [file]    // downloads the url to the (relative) file local path specifed and adds
                                     // its URL+ETag in dotnet-config
     dotnet file update [file]       // updates a specific file, based on its dotnet-config configuration
     dotnet file update [url]        // updates a specific file by its url, based on its dotnet-config configuration

--- a/src/Directory.props
+++ b/src/Directory.props
@@ -9,6 +9,7 @@
     <PackageOutputPath Condition="'$(PackOnBuild)' == 'true' And '$(PackageOutputPath)' == ''">$(MSBuildThisFileDirectory)..\bin</PackageOutputPath>
 
     <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin\')">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin'));$(RestoreSources)</RestoreSources>
+    <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)..\..\dotnet-config\bin\')">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\dotnet-config\bin'));$(RestoreSources)</RestoreSources>
   </PropertyGroup>
 
 </Project>

--- a/src/Directory.targets
+++ b/src/Directory.targets
@@ -1,8 +1,9 @@
 <Project>
   <!-- Extend the Directory.Build.targets -->
 
-  <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin\')">
-    <PackageReference Update="ThisAssembly" Version="42.42.42" />
+  <ItemGroup>
+    <PackageReference Update="ThisAssembly" Version="42.42.42" Condition="Exists('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin\')" />
+    <PackageReference Update="DotNetConfig" Version="42.42.42" Condition="Exists('$(MSBuildThisFileDirectory)..\..\dotnet-config\bin\')" />
   </ItemGroup>
 
 </Project>

--- a/src/File/Command.cs
+++ b/src/File/Command.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet
 
         public abstract Task<int> ExecuteAsync();
 
-        protected IEnumerable<FileSpec> GetConfiguredFiles()
+        protected internal IEnumerable<FileSpec> GetConfiguredFiles()
         {
             foreach (var file in Configuration.Where(x => x.Section == "file").GroupBy(x => x.Subsection))
             {

--- a/src/File/File.csproj
+++ b/src/File/File.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="ThisAssembly" Version="1.0.0" />
     <PackageReference Include="ColoredConsole" Version="1.0.0" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
-    <PackageReference Include="dotnet-config-lib" Version="1.0.0-beta" />
+    <PackageReference Include="DotNetConfig" Version="1.0.0-rc.1" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
   </ItemGroup>
 

--- a/src/File/InitCommand.cs
+++ b/src/File/InitCommand.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using ColoredConsole;
+using DotNetConfig;
+
+namespace Microsoft.DotNet
+{
+    class InitCommand : Command
+    {
+        public InitCommand(Config configuration) : base(configuration) { }
+
+        public override async Task<int> ExecuteAsync()
+        {
+            if (Files.Count == 0)
+            {
+                ColorConsole.Write("Init requires at least one URI to fetch initial .netconfig from.");
+                return 0;
+            }
+
+            var configs = new List<string>();
+            var result = 0;
+
+            // First download all the temp configs
+            foreach (var spec in Files)
+            {
+                var tempConfig = Path.GetTempFileName();
+                var tempFile = Path.GetTempFileName();
+                var command = new AddCommand(Config.Build(tempConfig));
+                command.Files.Add(new FileSpec(tempFile, spec.Uri));
+
+                ColorConsole.WriteLine("Downloading seed config file(s)...".Yellow());
+                if (await command.ExecuteAsync() != 0)
+                    result = -1;
+
+                configs.Add(tempFile);
+            }
+
+            // Then merge with the current config
+            foreach (var entry in configs.SelectMany(x => Config.Build(x)).Where(x => x.Level == null))
+            {
+                // Internally, setting a null string is actually valid. Maybe reflect that in the API too?
+                Configuration.SetString(entry.Section, entry.Subsection, entry.Variable, entry.RawValue!);
+            }
+
+            foreach (var config in configs.Select(x => Config.Build(x)))
+            {
+                // Process each downloaded .netconfig as a source of files 
+                var files = new UpdateCommand(config).GetConfiguredFiles();
+                // And update them against the current dir config.
+                var update = new UpdateCommand(Config.Build());
+                update.Files.AddRange(files);
+
+                if (await update.ExecuteAsync() != 0)
+                    result = -1;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/File/Program.cs
+++ b/src/File/Program.cs
@@ -28,6 +28,7 @@ namespace Microsoft.DotNet
                 "add" => new AddCommand(config),
                 "changes" => new ChangesCommand(config),
                 "delete" => new DeleteCommand(config),
+                "init" => new InitCommand(config),
                 "list" => new ListCommand(config),
                 "sync" => new SyncCommand(config),
                 "update" => new UpdateCommand(config),


### PR DESCRIPTION
Allows passing one or more URLs to `init` command, which downloads to temporary path and is used to configure the local directory prior to running `update` automatically.

We aggregate behavior from both `AddCommand` and `UpdateCommand` for this to reuse the auth and raw files support in both.

Fixes #18